### PR TITLE
Fix MPS OOM by forcing CPU embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ dream_bot/
 export PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.7
 ```
 
+`MPS backend out of memory` 오류가 계속된다면 임베딩 모델을
+CPU에서 실행하도록 설정하세요. 본 저장소의 기본 코드(`app/app.py`)는
+이미 CPU 모드로 동작하도록 수정되어 있습니다.
+
 ## 🔧 고급 설정
 
 ### PDF 교체

--- a/app/app.py
+++ b/app/app.py
@@ -56,7 +56,10 @@ class DreamRAGBot:
     def _load_embedder(self):
         """임베딩 모델 로드"""
         with st.spinner("🧠 임베딩 모델 로딩..."):
-            self.embedder = SentenceTransformer(self.config['embedding_model'])
+            # MPS 메모리 부족 현상 방지를 위해 CPU 강제 사용
+            self.embedder = SentenceTransformer(
+                self.config['embedding_model'], device="cpu"
+            )
             self.embedder.max_seq_length = 512
     
     def _load_llm(self):

--- a/scripts/build_index.py
+++ b/scripts/build_index.py
@@ -30,7 +30,8 @@ class PDFIndexBuilder:
             embedding_model_name: 임베딩 모델 이름 (e5-base는 한국어 지원)
         """
         print(f"🚀 임베딩 모델 로딩: {embedding_model_name}")
-        self.embedder = SentenceTransformer(embedding_model_name)
+        # MPS 환경에서 메모리 부족을 방지하기 위해 CPU 사용
+        self.embedder = SentenceTransformer(embedding_model_name, device="cpu")
         
         # M2 Mac 최적화: 배치 크기 축소
         self.embedder.max_seq_length = 512  # 메모리 절약


### PR DESCRIPTION
## Summary
- avoid GPU memory overflow by loading embedding models on CPU
- note the CPU workaround in README

## Testing
- `python -m py_compile app/app.py scripts/build_index.py`

------
https://chatgpt.com/codex/tasks/task_e_685ceebae8e4832b9050ee949aa1f2ea